### PR TITLE
Upgraded OpenTK and added a cleanup

### DIFF
--- a/OpenTkControl/OpenTkControl.csproj
+++ b/OpenTkControl/OpenTkControl.csproj
@@ -33,8 +33,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenTK.2.0.0\lib\net20\OpenTK.dll</HintPath>
+    <Reference Include="OpenTK, Version=3.2.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenTK.3.2\lib\net20\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/OpenTkControl/Properties/AssemblyInfo.cs
+++ b/OpenTkControl/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1")]
-[assembly: AssemblyFileVersion("1.0.1")]
+[assembly: AssemblyVersion("1.0.2")]
+[assembly: AssemblyFileVersion("1.0.2")]

--- a/OpenTkControl/packages.config
+++ b/OpenTkControl/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenTK" version="2.0.0" />
+  <package id="OpenTK" version="3.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The OpenTK reference has been upgraded.

Added a cleanup event that it's called when the current OpenGL context it's about to get destroyed. That gives a chance to the application to free any unmanaged resources that requires the OpenGL context to be active (like texture handlers, vbos, etc)

The unloaded event it's not called if the control it's destroyed due to the application shutting down. To prevent any issues or even memory leaks (because of unmanaged resources dependent on the OpenGL's context) the control suscribes to the current application's shutdown event to release all the unmanaged resources and raise the cleanup event, so all the system can be stopped gracefully and the application has always a chance to release unmanaged resources if needed.